### PR TITLE
split 2 cli & lib + use proper spec types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+swagger.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bin
+dist/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/kingsquare/communibase-swagger.git",
   "author": "Kingsquare BV <source@kingsquare.nl>",
   "license": "ISC",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "prepublishOnly": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -18,10 +18,12 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "communibase-connector-js": "^1.0.5"
+    "@types/swagger-schema-official": "^2.0.18",
+    "bluebird": "^3.7.0",
+    "communibase-connector-js": "^1.0.5",
+    "swagger-schema-official": "^2.0.0-bab6bed"
   },
   "devDependencies": {
-    "bluebird": "^3.7.0",
     "prettier": "^1.15.3",
     "tslint": "^5.12.0",
     "tslint-config-kingsquare": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,27 @@
 {
   "name": "communibase-swagger",
-  "version": "0.0.5",
-  "description": "",
+  "version": "0.1.0",
+  "description": "Generate Swagger compatible definitions for Communibase API",
+  "repository": "https://github.com/kingsquare/communibase-swagger.git",
+  "author": "Kingsquare BV <source@kingsquare.nl>",
+  "license": "ISC",
   "main": "index.js",
   "scripts": {
     "prepublishOnly": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC",
+  "bin": {
+    "cbswagger": "./dist/cli.js"
+  },
+  "files": [
+    "README.md",
+    "dist/**/*"
+  ],
   "dependencies": {
     "communibase-connector-js": "^1.0.5"
   },
-  "bin": {
-    "cbswagger": "./bin/cbswagger.js"
-  },
   "devDependencies": {
+    "bluebird": "^3.7.0",
     "prettier": "^1.15.3",
     "tslint": "^5.12.0",
     "tslint-config-kingsquare": "^5.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import generator from "./index";
+
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+
+const outputFileName = process.argv[3] || "swagger.json";
+
+generator({ apiKey: process.argv[2] })
+  .then((swagger: object) => {
+    const path = resolve(outputFileName);
+    writeFileSync(path, JSON.stringify(swagger, null, "\t"), {
+      encoding: "utf8",
+      flag: "w"
+    });
+
+    console.log(`Created ${path}`);
+  })
+  .catch((err: Error) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,19 +101,28 @@ export default async ({
   }
   const entityTypes = await cbc.getAll<ICbEntity>("EntityType");
 
-  const definitions: { [title: string]: Schema } = {};
+  const idDefinition: Schema = {
+    type: "string",
+    minLength: 24,
+    maxLength: 24
+  };
+
+  const definitions: { [title: string]: Schema } = {
+    // TODO full EntityType definition
+    EntityType: {
+      type: "object",
+      properties: {
+        _id: idDefinition
+      }
+    }
+  };
 
   entityTypes.forEach(entityType => {
     const definition: Schema = {
       type: "object",
       properties: {
-        _id: {
-          type: "string",
-          minLength: 24,
-          maxLength: 24
-        }
-      },
-      required: []
+        _id: idDefinition
+      }
     };
     definition.properties = definition.properties || {};
 
@@ -143,15 +152,17 @@ export default async ({
   return {
     swagger: "2.0",
     info: {
-      version: "0.0.1",
-      title: "CB API",
-      description: "A RESTful API for Communibase"
+      version: "1.0.0",
+      title: "Communibase API for X",
+      description: "A RESTful API for Communibase administration X"
     },
     host: "api.communibase.nl",
     basePath: "/v1",
     tags: [],
     schemes: ["https"],
     produces: ["application/json"],
+
+    // TODO full Paths definition
     paths: {
       "/EntityType.json/crud": {
         get: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["esnext"],
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./bin",
+    "outDir": "./dist",
     "strict": true
   },
   "include": ["src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,6 +126,11 @@ bluebird@^3.5.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
+bluebird@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
+  integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,6 +27,11 @@
   resolved "https://registry.yarnpkg.com/@types/socket.io-client/-/socket.io-client-1.4.32.tgz#988a65a0386c274b1c22a55377fab6a30789ac14"
   integrity sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==
 
+"@types/swagger-schema-official@^2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.18.tgz#5ce35ec9949ff5b5bfec69b83f5bc3dd63a4dd97"
+  integrity sha512-zQsYKjtPf7Hvnp6KR4DTypXZ12tlH7k670d4QXuxzkofefBy9e2GwRKyV06lgTi3qw/OH/JFTDYe/x3uQmnusQ==
+
 "@types/winston@^2.3.9":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/winston/-/winston-2.4.4.tgz#48cc744b7b42fad74b9a2e8490e0112bd9a3d08d"
@@ -753,6 +758,11 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+swagger-schema-official@^2.0.0-bab6bed:
+  version "2.0.0-bab6bed"
+  resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz#70070468d6d2977ca5237b2e519ca7d06a2ea3fd"
+  integrity sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0=
 
 text-hex@1.0.x:
   version "1.0.0"


### PR DESCRIPTION
### This splits this into a library and a cli

 * allows using as a library which returns the spec as a json object
 * still has the cli (which uses the library)

### Also the library now uses the official swagger types instead of an own type. And returns this type.

### Things needed to be done to fix the specification for possible upstream `dtsgenerator` to work without problems;

 * adds a _basic_ `EntityType` definition as else the specified path `$ref` failed

### Things still need to be done;

 * should generate proper `EntityType` definition ?
 * should generate all paths

Fixing all of the above could then mean that we can use this library within communibase itself for generating it's specification..

### Misc things

 * Adds repo information to the `package.json` this ensures that npm has the repo link
 * exports the `ICBSwaggerGeneratorOptions` interface for downstream to consume

### Could have

Maybe a CB administration should have it's title in it's Settings? This way we can also include the administration title in the specification `Specification for X`
 
### Why

_This was all done for the hatchery project https://github.com/vindaloopoo/communibase-types-generator_
